### PR TITLE
Board 리스트, 등록, 상세페이지 구현완료 / test db 자동 등록 로직 구현

### DIFF
--- a/src/main/java/com/huh/BaekJoonSupporter/board/Board.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/Board.java
@@ -44,12 +44,13 @@ public class Board {
     private List<Comment> comments = new ArrayList<>();
 
     //-- create method --//
-    public static Board create(String title, String post, Member member) {
+    protected static Board create(String title, String post, Member member) {
         Board board = Board
                 .builder()
                 .title(title)
                 .post(post)
                 .member(member)
+                .view(0)
                 .build();
 
         member.getBoards().add(board);
@@ -59,10 +60,15 @@ public class Board {
     //-- business method --//
 
     //- modify -//
-    public Board modify(String title, String post) {
+    protected Board modify(String title, String post) {
         return this.toBuilder()
                 .title(title)
                 .post(post)
                 .build();
+    }
+
+    //- view adder -//
+    protected void addView() {
+        this.view++;
     }
 }

--- a/src/main/java/com/huh/BaekJoonSupporter/board/Board.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/Board.java
@@ -29,6 +29,7 @@ public class Board {
 
     private String title;
     private String post;
+    private Integer view;
 
     @CreatedDate
     private LocalDateTime createDate;
@@ -39,6 +40,7 @@ public class Board {
     private Member member;
 
     @OneToMany(mappedBy = "board")
+    @Builder.Default
     private List<Comment> comments = new ArrayList<>();
 
     //-- create method --//

--- a/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
@@ -48,10 +48,10 @@ public class BoardController {
             BindingResult bindingResult,
             Principal principal
     ) {
-        Member member = memberService.getMember("글쓴이");
+        // 로그인 기능 구현 되면 principal.getName 을 바꿔야 함
+        Member member = memberService.getMember("init 글쓴이");
         boardService.create(boardCreateForm.getTitle(), boardCreateForm.getPost(), member);
         return "redirect:/board/list";
-//        return "/board/create";
     }
 
     //-- 게시물 디테일 --//

--- a/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
@@ -9,10 +9,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
@@ -51,8 +48,22 @@ public class BoardController {
             BindingResult bindingResult,
             Principal principal
     ) {
-        Member member = memberService.getMember(principal.getName());
+        Member member = memberService.getMember("글쓴이");
         boardService.create(boardCreateForm.getTitle(), boardCreateForm.getPost(), member);
         return "redirect:/board/list";
+//        return "/board/create";
+    }
+
+    //-- 게시물 디테일 --//
+    @GetMapping("/detail/{id}")
+    public String showDetail(
+            @PathVariable Long id,
+            Model model
+    ) {
+        Board board = boardService.getBoard(id);
+        boardService.viewAdder(board);
+
+        model.addAttribute("board", board);
+        return "/board/detail";
     }
 }

--- a/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
@@ -7,16 +7,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-<<<<<<< HEAD
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-=======
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
->>>>>>> DeaKuk40
 
 @Controller
 @RequestMapping("/board")
@@ -47,7 +42,7 @@ public class BoardController {
 
     //-- 게시물 생성 처리 --//
     @PostMapping("/create")
-//    @PreAuthorize("isAuthenticated()")
+//    @PreAuthorize("isAuthenticated()") // 로그인 기능 완성 후 활성화 해야됨
     public String showCreateForm(
             BoardCreateForm boardCreateForm,
             BindingResult bindingResult,
@@ -63,6 +58,7 @@ public class BoardController {
     @GetMapping("/detail/{id}")
     public String showDetail(
             @PathVariable Long id,
+            Principal principal,
             Model model
     ) {
         Board board = boardService.getBoard(id);

--- a/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
@@ -2,6 +2,7 @@ package com.huh.BaekJoonSupporter.board;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -11,5 +12,8 @@ public class BoardController {
 
     private final BoardService boardService;
 
-
+    @GetMapping("/list")
+    public String showList() {
+        return "/board/boardList";
+    }
 }

--- a/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/BoardController.java
@@ -1,9 +1,20 @@
 package com.huh.BaekJoonSupporter.board;
 
+import com.huh.BaekJoonSupporter.board.form.BoardCreateForm;
+import com.huh.BaekJoonSupporter.member.Member;
+import com.huh.BaekJoonSupporter.member.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.security.Principal;
 
 @Controller
 @RequestMapping("/board")
@@ -11,9 +22,37 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class BoardController {
 
     private final BoardService boardService;
+    private final MemberService memberService;
 
+    //-- 게시판 전체 목록 --//
     @GetMapping("/list")
-    public String showList() {
+    public String showList(
+            @RequestParam(defaultValue = "0") int pate,
+            Principal principal,
+            Model model
+    ) {
+        Page<Board> paging = boardService.getBoardAll(pate);
+        model.addAttribute("paging", paging);
         return "/board/boardList";
+    }
+
+    //-- 게시물 생성 폼 --//
+    @GetMapping("/create")
+//    @PreAuthorize("isAuthenticated()")
+    public String showCreateForm(BoardCreateForm boardCreateForm) {
+        return "/board/create";
+    }
+
+    //-- 게시물 생성 처리 --//
+    @PostMapping("/create")
+//    @PreAuthorize("isAuthenticated()")
+    public String showCreateForm(
+            BoardCreateForm boardCreateForm,
+            BindingResult bindingResult,
+            Principal principal
+    ) {
+        Member member = memberService.getMember(principal.getName());
+        boardService.create(boardCreateForm.getTitle(), boardCreateForm.getPost(), member);
+        return "redirect:/board/list";
     }
 }

--- a/src/main/java/com/huh/BaekJoonSupporter/board/BoardRepository.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/BoardRepository.java
@@ -1,6 +1,10 @@
 package com.huh.BaekJoonSupporter.board;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    Page<Board> findAll(Pageable pageable);
 }

--- a/src/main/java/com/huh/BaekJoonSupporter/board/BoardService.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/BoardService.java
@@ -1,10 +1,12 @@
 package com.huh.BaekJoonSupporter.board;
 
+import com.huh.BaekJoonSupporter.DataNotFoundException;
 import com.huh.BaekJoonSupporter.member.Member;
 import com.huh.BaekJoonSupporter.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,7 +38,7 @@ public class BoardService {
         if (board.isPresent())
             return board.get();
 
-        return null;
+        throw new DataNotFoundException("게시물을 찾을 수 없습니다.");
     }
 
     //-- find all --//
@@ -49,7 +51,7 @@ public class BoardService {
         List<Sort.Order> sorts = new ArrayList<>();
         sorts.add(Sort.Order.desc("createDate"));
 
-        PageRequest pageable = PageRequest.of(page, 10, Sort.by(sorts));
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(sorts));
         return boardRepository.findAll(pageable);
     }
 
@@ -69,5 +71,11 @@ public class BoardService {
         member.getBoards().remove(board);
         boardRepository.delete(board);
 
+    }
+
+    //-- view counter --//
+    @Transactional
+    public void viewAdder(Board board) {
+        board.addView();
     }
 }

--- a/src/main/java/com/huh/BaekJoonSupporter/board/BoardService.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/BoardService.java
@@ -3,9 +3,13 @@ package com.huh.BaekJoonSupporter.board;
 import com.huh.BaekJoonSupporter.member.Member;
 import com.huh.BaekJoonSupporter.member.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,6 +42,15 @@ public class BoardService {
     //-- find all --//
     public List<Board> getBoardAll() {
         return boardRepository.findAll();
+    }
+
+    //-- find all + paging --//
+    public Page<Board> getBoardAll(int page) {
+        List<Sort.Order> sorts = new ArrayList<>();
+        sorts.add(Sort.Order.desc("createDate"));
+
+        PageRequest pageable = PageRequest.of(page, 10, Sort.by(sorts));
+        return boardRepository.findAll(pageable);
     }
 
     //-- modify --//

--- a/src/main/java/com/huh/BaekJoonSupporter/board/form/BoardCreateForm.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/form/BoardCreateForm.java
@@ -1,4 +1,17 @@
 package com.huh.BaekJoonSupporter.board.form;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
 public class BoardCreateForm {
+
+    @NotEmpty(message = "제목을 입력해주세요.")
+    @Size(min = 1, max = 150)
+    private String title;
+    @NotEmpty(message = "내용을 입력해주세요.")
+    private String post;
 }

--- a/src/main/java/com/huh/BaekJoonSupporter/board/initDB/InitDB.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/initDB/InitDB.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Component
+//@Component // db 자동 init 하려면 활성화
 @RequiredArgsConstructor
 public class InitDB {
 

--- a/src/main/java/com/huh/BaekJoonSupporter/board/initDB/InitDB.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/board/initDB/InitDB.java
@@ -1,0 +1,40 @@
+package com.huh.BaekJoonSupporter.board.initDB;
+
+import com.huh.BaekJoonSupporter.board.BoardService;
+import com.huh.BaekJoonSupporter.member.Member;
+import com.huh.BaekJoonSupporter.member.MemberService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class InitDB {
+
+    private final InitService initService;
+
+    @PostConstruct
+    public void init() {
+        initService.dbInit1();
+    }
+
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService {
+
+        private final BoardService boardService;
+        private final MemberService memberService;
+
+        public void dbInit1() {
+            memberService.create("init 글쓴이", "", "토큰");
+
+            for (int i = 1; i < 30; i++) {
+                Member member = memberService.getMember("init 글쓴이");
+                boardService.create("제목" + i, "내용" + i, member);
+            }
+
+        }
+    }
+}

--- a/src/main/java/com/huh/BaekJoonSupporter/member/Member.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/member/Member.java
@@ -6,9 +6,10 @@ import com.huh.BaekJoonSupporter.team.Team;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @Entity
 @NoArgsConstructor
@@ -27,7 +28,8 @@ public class Member {
     private String token;
 
     @OneToMany(mappedBy = "member")
-    private List<Board> boards;
+    @Builder.Default
+    private List<Board> boards = new ArrayList<>();
 
     @ManyToOne
     private Team team;

--- a/src/main/java/com/huh/BaekJoonSupporter/member/MemberService.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/member/MemberService.java
@@ -12,12 +12,12 @@ import java.util.Optional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
+//    private final PasswordEncoder passwordEncoder;
 
     public void create(String name, String password, String token) {
         Member member = Member.builder()
                 .name(name)
-                .password(passwordEncoder.encode(password))
+//                .password(passwordEncoder.encode(password))
                 .token(token)
                 .build();
         memberRepository.save(member);
@@ -35,7 +35,7 @@ public class MemberService {
     public void modify(String name, String password, String token) {
         Member member = Member.builder()
                 .name(name)
-                .password(passwordEncoder.encode(password))
+//                .password(passwordEncoder.encode(password))
                 .token(token)
                 .build();
         memberRepository.save(member);

--- a/src/main/resources/templates/board/boardList.html
+++ b/src/main/resources/templates/board/boardList.html
@@ -1,0 +1,105 @@
+<html layout:decorate="~{layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+<div layout:fragment="content" class="py-12">
+
+    <h5 class="text-lg font-semibold mb-4">게시판</h5>
+
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+        <tr>
+            <th scope="col"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                번호
+            </th>
+            <th scope="col"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-1/2">
+                제목
+            </th>
+            <th scope="col"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                글쓴이
+            </th>
+            <th scope="col"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                작성일
+            </th>
+            <th scope="col"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                조회
+            </th>
+        </tr>
+        </thead>
+
+        <tbody class="bg-white divide-y divide-gray-200">
+        <tr th:each="board, loop : ${paging}">
+
+            <!-- 게시물 번호 -->
+            <td class="px-6 py-4 whitespace-nowrap">
+                <div class="text-sm text-gray-900" th:text="${paging.getTotalElements - (paging.number * paging.size) - loop.index}"></div>
+            </td>
+
+            <!-- 게시글 + 댓글 수 -->
+            <td class="px-6 py-4 whitespace-nowrap">
+                <div class="text-sm text-gray-900">
+                    <a th:href="@{|/board/detail/${board.id}|}"
+                       th:text="${board.title}"
+                       class="text-indigo-600 hover:text-indigo-900"></a>
+                    <span th:if="${#lists.size(board.comments) > 0}"
+                          th:text="${#lists.size((board.comments))}"
+                          class="ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800"></span>
+                </div>
+            </td>
+
+            <!-- 글쓴이 -->
+            <td class="px-6 py-4 whitespace-nowrap">
+            <span th:if="${board.member != null}"
+                  th:text="${board.member.name}"
+                  class="text-sm text-gray-500"></span>
+            </td>
+
+            <!-- 작성일 -->
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <div th:text="${#temporals.format(board.createDate, 'yyyy-MM-dd HH:mm')}"></div>
+            </td>
+
+            <!-- 조회수 -->
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <div th:text="${board.view}?: '0'"></div>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+
+    <!-- 페이징 처리 시작 -->
+    <div th:if="${!paging.isEmpty()}">
+        <ul>
+
+            <li th:classappend="${!paging.hasPrevious} ? 'disabled'">
+                <a th:href="@{|?page=${paging.number - 1}|}">
+                    <span>이전</span>
+                </a>
+            </li>
+
+            <li th:each="page: ${#numbers.sequence(0, paging.totalPages - 1)}"
+                th:classappend="${page == paging.number} ? 'active'"
+                th:if="${page >= paging.number - 2 and page <= paging.number + 2}">
+                <a th:text="${page}" th:href="@{|?page=${page}|}"></a>
+            </li>
+
+            <li th:classappend="${!paging.hasNext} ? 'disabled'">
+                <a th:href="@{|?page=${paging.number + 1}|}">
+                    <span>다음</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+    <!-- 페이징 처리 종료 -->
+
+    <a href="/board/create"
+       class="bg-blue-500 text-white py-2 px-4
+               rounded-md hover:bg-blue-600 transition
+               duration-200 ease-in-out cursor-pointer">
+        게시물 등록
+    </a>
+
+</div>
+</html>

--- a/src/main/resources/templates/board/boardList.html
+++ b/src/main/resources/templates/board/boardList.html
@@ -75,13 +75,13 @@
 
             <li th:classappend="${!paging.hasPrevious} ? 'disabled'">
                 <a th:href="@{|?page=${paging.number - 1}|}">
-                    <span>이전</span>
+                    이전
                 </a>
             </li>
 
             <li th:each="page: ${#numbers.sequence(0, paging.totalPages - 1)}"
                 th:classappend="${page == paging.number} ? 'active'"
-                th:if="${page >= paging.number - 2 and page <= paging.number + 2}">
+                th:if="${page >= paging.number - 5 and page <= paging.number + 5}">
                 <a th:text="${page}" th:href="@{|?page=${page}|}"></a>
             </li>
 

--- a/src/main/resources/templates/board/boardTemplate/getBoard.html
+++ b/src/main/resources/templates/board/boardTemplate/getBoard.html
@@ -1,0 +1,3 @@
+<div th:fragment="getboard">
+    하이
+</div>

--- a/src/main/resources/templates/board/boardTemplate/getBoard.html
+++ b/src/main/resources/templates/board/boardTemplate/getBoard.html
@@ -1,3 +1,29 @@
-<div th:fragment="getboard">
-    하이
+<div th:fragment="details (board)">
+
+    <div class="max-w-4xl mx-auto p-8">
+
+        <h1 class="text-4xl font-bold mb-4">게시판</h1>
+
+        <div class="bg-white shadow-lg rounded-lg overflow-hidden">
+            <div class="px-6 py-4">
+                <h2 class="text-2xl font-bold mb-2"
+                    th:text="${board.title}"></h2>
+                <p class="text-gray-700 text-base"
+                   th:text="${board.post}"></p>
+            </div>
+
+            <div class="bg-gray-100 px-6 py-4">
+                <span th:text="${#temporals.format(board.createDate, 'yyyy-MM-dd HH:mm')}"
+                      class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2"></span>
+
+                <span th:if="${board.createDate ge board.modifyDate}"
+                      th:text="${#temporals.format(board.modifyDate, 'yyyy-MM-dd HH:mm')}"
+                      class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700"></span>
+            </div>
+        </div>
+        <div class="mt-4">
+            <a href="/board/list" class="text-blue-500">목록으로 돌아가기</a>
+        </div>
+    </div>
+
 </div>

--- a/src/main/resources/templates/board/create.html
+++ b/src/main/resources/templates/board/create.html
@@ -1,0 +1,48 @@
+<html layout:decorate="~{layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+<div layout:fragment="content" class="p-4">
+
+    <h5 class="text-lg font-semibold mb-4">질문등록</h5>
+
+    <form method="post"
+          th:object="${boardCreateForm}"
+          class="space-y-4">
+
+        <input type="hidden"
+               th:name="${_csrf.parameterName}"
+               th:value="${_csrf.token}"/>
+
+        <div class="flex flex-col">
+            <label for="title"
+                   class="text-sm font-medium mb-1">제목</label>
+            <input type="text"
+                   th:field="*{title}"
+                   class="border
+                   border-gray-300 py-2 px-3
+                   rounded-lg
+                   focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"/>
+        </div>
+        <div class="flex flex-col">
+            <label for="post"
+                   class="text-sm font-medium mb-1">내용</label>
+            <textarea th:field="*{post}" rows="8"
+                      class="border
+                      border-gray-300 py-2 px-3 rounded-lg
+                      focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"></textarea>
+        </div>
+
+        <input type="submit"
+               value="저장하기"
+               class="bg-blue-500 text-white py-2 px-4
+               rounded-md hover:bg-blue-600 transition
+               duration-200 ease-in-out cursor-pointer">
+
+        <a href="/board/list"
+           class="bg-blue-500 text-white py-2 px-4
+               rounded-md hover:bg-blue-600 transition
+               duration-200 ease-in-out cursor-pointer">
+            돌아가기
+        </a>
+    </form>
+
+</div>
+</html>

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -1,0 +1,9 @@
+<html layout:decorate="~{layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+<div layout:fragment="content" class="py-12">
+
+  <h5 class="text-lg font-semibold mb-4" th:text="${board.title}"></h5>
+
+  <div th:replace="~{templates/board/boardTemplate/getBoard} :: getBoard}"></div>
+
+</div>
+</html>

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -1,9 +1,7 @@
 <html layout:decorate="~{layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
 <div layout:fragment="content" class="py-12">
 
-  <h5 class="text-lg font-semibold mb-4" th:text="${board.title}"></h5>
-
-  <div th:replace="~{templates/board/boardTemplate/getBoard} :: getBoard}"></div>
+  <div th:replace="~{board/boardTemplate/getBoard :: details (${board})}"></div>
 
 </div>
 </html>


### PR DESCRIPTION
### ✅ 수정 사항 요약
- 완료 : 
- Board 리스트 개발
    - 생성일 구현
    - 글쓴이 기능 구현
    - 조회수 기능 구현
- Board 등록 폼 / 처리 개발
- Board 상세 페이지 개발
    - 생성일, 수정일 구현
- Board 자동 생성 로직 구현
    - 활성화 시키면 서버실행시 29 개 게시물 생성됨 (비활성화 시켜둠)
<br>
- 참고 : 
- 게시물을 생성하려면 로그인을 해야되서 로그인 기능 구현까지 게시물 등록하면 에러가 발생됩니다.
- 게시판 상세페이지는 템플릿 조각을 사용해서 제작되었습니다.
    - 댓글기능도 템플릿 사용해서 구현하시면 됩니다!

<br>
- 페이징 기능이 작동하지 않습니다.
    - 아직 원인을 모르겠어서 최대한 빠르게 파악후 정상작동 시키겠습니다.
    - 페이징 CSS 적용이 안되었습니다 ㅜㅜ 아직 마땅히 사용할만한 소스를 찾지못했습니다 ㅠㅠ

### ✅ 다음 계획
- 게시물 수정기능 구현
- 게시물 삭제기능 구현
