### PR TITLE
fix: 비밀번호 변경 검증 & feat: showMe()

### DIFF
--- a/src/main/java/com/huh/BaekJoonSupporter/member/Member.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/member/Member.java
@@ -31,7 +31,7 @@ public class Member {
     @Builder.Default
     private List<Board> boards = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Team team;
 
     @OneToMany(mappedBy = "member")

--- a/src/main/java/com/huh/BaekJoonSupporter/member/MemberController.java
+++ b/src/main/java/com/huh/BaekJoonSupporter/member/MemberController.java
@@ -33,4 +33,10 @@ public class MemberController {
     public String login() {
         return "/member/login_form";
     }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/me")
+    public String showMe() {
+        return "/member/me";
+    }
 }

--- a/src/main/resources/templates/member/me.html
+++ b/src/main/resources/templates/member/me.html
@@ -1,0 +1,5 @@
+<html layout:decorate="~{layout}">
+<div layout:fragment="content" class="py-12 flex justify-center">
+
+</div>
+</html>

--- a/src/test/java/com/huh/BaekJoonSupporter/member/MemberServiceTest.java
+++ b/src/test/java/com/huh/BaekJoonSupporter/member/MemberServiceTest.java
@@ -23,20 +23,22 @@ public class MemberServiceTest {
     private PasswordEncoder passwordEncoder;
 
     @Test
-    void create_modify(){
-        //create and getMember
+    void memberTests(){
+        // create
         Member createMember = memberService.create("user1", "1234", "aaaa");
+        assertThat(memberRepository.findByName("user1")).isNotEmpty();
+
+        // get
         Member member = memberService.getMember("user1");
+        assertThat(member).isEqualTo(memberRepository.findByName("user1").get());
 
-        assertThat(createMember).isEqualTo(member);
+        // modify - 패스워드, 토큰 둘 다 변경
+        memberService.modify(member, "1111", "bbbb");
 
-        // modify
-        memberService.modify(member, "1234", "bbbb");
-        member = memberService.getMember("user1");
-
+        assertThat(passwordEncoder.matches("1111", member.getPassword())).isTrue();
         assertThat(member.getToken()).isEqualTo("bbbb");
 
-        //delete
+        // delete
         memberService.delete(member);
         Member member1 = memberRepository.findByName("user1").orElse(null);
         assertThat(member1).isNull();;


### PR DESCRIPTION
### ✅ 수정 사항 요약
- 완료 :
- 테스트 시 비밀번호 변경 검증 로직을 추가했습니다.
- 내 정보 페이지에 대한 컨트롤러 메서드(showMe())를 추가했습니다.

- 참고 : 

### ✅ 다음 계획
- 내 정보 페이지의 html 파일(/member/me.html) 작성
